### PR TITLE
hotfix: redirect_uri 수정 및 webflux 의존성 추가

### DIFF
--- a/backend/goodday/build.gradle
+++ b/backend/goodday/build.gradle
@@ -19,6 +19,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation:2.3.3.RELEASE'
 
+	// webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	// log
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
@@ -34,6 +37,8 @@ dependencies {
 	// test
 	testImplementation 'io.rest-assured:rest-assured:3.3.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+
 }
 
 test {

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/KakaoController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/KakaoController.java
@@ -27,7 +27,7 @@ public class KakaoController {
         StringBuffer url = new StringBuffer();
         url.append(KAKAO_AUTH_URI + "/oauth/authorize?");
         url.append("client_id=" + SecretKey.KAKAO_API_KEY);
-        url.append("&redirect_uri=https://seeyouthere.o-r.kr/api/kakao/callback");
+        url.append("&redirect_uri="+ Kakao.DOMAIN_URI +"/api/kakao/callback");
         url.append("&response_type=code");
 
         return "redirect:" + url;

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/KakaoController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/KakaoController.java
@@ -1,130 +1,47 @@
 package seeuthere.goodday.auth.controller;
 
-import java.io.IOException;
+import static seeuthere.goodday.auth.domain.Kakao.KAKAO_AUTH_URI;
+import static seeuthere.goodday.auth.domain.Kakao.KAKAO_HOST_URI;
+
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.json.simple.JSONObject;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import seeuthere.goodday.member.domain.Member;
-import seeuthere.goodday.member.service.MemberService;
+import seeuthere.goodday.auth.domain.Kakao;
 import seeuthere.goodday.secret.SecretKey;
 
 
 @Controller
-@RequestMapping("/kakao")
+@RequestMapping("/api/kakao")
 public class KakaoController {
-
-    private static final String KAKAO_HOST_URI = "https://kapi.kakao.com";
-    private static final String KAKAO_AUTH_URI = "https://kauth.kakao.com";
-
-    private final MemberService memberService;
-
-    public KakaoController(MemberService memberService) {
-        this.memberService = memberService;
-    }
 
     @GetMapping(value = "/oauth")
     public String kakaoConnect() {
         StringBuffer url = new StringBuffer();
         url.append(KAKAO_AUTH_URI + "/oauth/authorize?");
         url.append("client_id=" + SecretKey.KAKAO_API_KEY);
-        url.append("&redirect_uri=http://localhost:8080/kakao/callback");
+        url.append("&redirect_uri=https://seeyouthere.o-r.kr/api/kakao/callback");
         url.append("&response_type=code");
 
         return "redirect:" + url;
     }
 
     @RequestMapping(value = "/callback", produces = "application/json", method = {RequestMethod.GET,
-        RequestMethod.POST})
-    public String kakaoLogin(@RequestParam("code") String code, RedirectAttributes ra,
-        HttpSession session, HttpServletResponse response, Model model) throws IOException {
-
-        Map<String, String> tokens = getKakaoAccessToken(code);
-
-        // 사용자 정보 받아오기
-        JSONObject userInfo = getKakaoUserInfo(tokens.get("access_token"));
+            RequestMethod.POST})
+    public String kakaoLogin(@RequestParam("code") String code, HttpSession session) {
+        Map<String, String> tokens = Kakao.getKakaoAccessToken(code);
         session.setAttribute("access_token", tokens.get("access_token"));
 
-        // 디비에 저장
-        Integer id = (Integer) userInfo.get("id");
-        Map<String, Object> map = (Map<String, Object>) userInfo.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) map.get("profile");
-        String name = (String) profile.get("nickname");
-        Member member = new Member(id, name);
-        if (memberService.find(id).isEmpty()) {
-            memberService.add(member);
-        }
-        Member inputMember = memberService.find(id).get();
-        System.out.println(inputMember.getId() + " " + inputMember.getName());
-
+        // 사용자 정보 받아오기 - 프론트한테 보낼 정보 협의
+        JSONObject access_token = Kakao.getKakaoUserInfo(tokens.get("access_token"));
         return null;
-    }
-
-    private JSONObject getKakaoUserInfo(String access_token) {
-        RestTemplate restTemplate = new RestTemplate();
-        String reqUrl = "/v2/user/me";
-        URI uri = URI.create(KAKAO_HOST_URI + reqUrl);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + access_token);
-
-        HttpEntity<MultiValueMap<String, Object>> restRequest = new HttpEntity<>(headers);
-        ResponseEntity<JSONObject> apiResponse = restTemplate
-            .postForEntity(uri, restRequest, JSONObject.class);
-        JSONObject responseBody = apiResponse.getBody();
-//        Map<String, Object> map = (Map<String, Object>) responseBody.get("kakao_account");
-        return responseBody;
-    }
-
-    public Map<String, String> getKakaoAccessToken(String code) {
-        String accessToken = "";
-
-        RestTemplate restTemplate = new RestTemplate();
-        String reqUrl = "/oauth/token";
-        URI uri = URI.create(KAKAO_AUTH_URI + reqUrl);
-
-        HttpHeaders headers = new HttpHeaders();
-
-        MultiValueMap<String, Object> parameters = new LinkedMultiValueMap<>();
-        parameters.set("grant_type", "authorization_code");
-        parameters.set("client_id", SecretKey.KAKAO_API_KEY);
-        parameters.set("redirect_uri", "http://localhost:8080/kakao/callback");
-        parameters.set("code", code);
-
-        HttpEntity<MultiValueMap<String, Object>> restRequest = new HttpEntity<>(parameters,
-            headers);
-        ResponseEntity<JSONObject> apiResponse = restTemplate
-            .postForEntity(uri, restRequest, JSONObject.class);
-        JSONObject responseBody = apiResponse.getBody();
-
-        HashMap<String, String> tokens = new HashMap<>();
-
-        accessToken = (String) responseBody.get("access_token");
-        String refreshToken = (String) responseBody.get("refresh_token");
-
-        tokens.put("access_token", accessToken);
-        tokens.put("refresh_token", refreshToken);
-
-/*        RestTemplate template = new RestTemplateBuilder()
-            .defaultHeader("Authorizatoin", "Bearer " + accessToken)
-            .build();
-        template.postForEntity(uri, restRequest, JSONObject.class);*/
-        return tokens;
     }
 
     @GetMapping(value = "/logout")
@@ -132,18 +49,12 @@ public class KakaoController {
         String accessToken = (String) session.getAttribute("access_token");
 
         RestTemplate restTemplate = new RestTemplate();
-        String reqUrl = "/v1/user/logout";
-        URI uri = URI.create(KAKAO_HOST_URI + reqUrl);
+        URI uri = URI.create(KAKAO_HOST_URI + "/v1/user/logout");
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + accessToken);
-
-        HttpEntity<MultiValueMap<String, Object>> restRequest = new HttpEntity<>(headers);
-        ResponseEntity<JSONObject> apiResponse = restTemplate
-            .postForEntity(uri, restRequest, JSONObject.class);
-        JSONObject responseBody = apiResponse.getBody();
+        Kakao.postRequest(restTemplate, uri, null, headers);
 
         session.removeAttribute("access_token");
-        Integer id = (Integer) responseBody.get("id");
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
@@ -35,7 +35,7 @@ public class Kakao {
         MultiValueMap<String, Object> parameters = new LinkedMultiValueMap<>();
         parameters.set("grant_type", "authorization_code");
         parameters.set("client_id", SecretKey.KAKAO_API_KEY);
-        parameters.set("redirect_uri", "http://localhost:8080/kakao/callback");
+        parameters.set("redirect_uri", "https://seeyouthere.o-r.kr/api/kakao/callback");
         parameters.set("code", code);
 
         ResponseEntity<JSONObject> apiResponse = postRequest(restTemplate, uri, parameters, null);

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
@@ -17,6 +17,7 @@ public class Kakao {
 
     public static final String KAKAO_HOST_URI = "https://kapi.kakao.com";
     public static final String KAKAO_AUTH_URI = "https://kauth.kakao.com";
+    public static final String DOMAIN_URI = "https://seeyouther.o-r.kr";
 
     public static JSONObject getKakaoUserInfo(String access_token) {
         RestTemplate restTemplate = new RestTemplate();
@@ -35,7 +36,7 @@ public class Kakao {
         MultiValueMap<String, Object> parameters = new LinkedMultiValueMap<>();
         parameters.set("grant_type", "authorization_code");
         parameters.set("client_id", SecretKey.KAKAO_API_KEY);
-        parameters.set("redirect_uri", "https://seeyouthere.o-r.kr/api/kakao/callback");
+        parameters.set("redirect_uri", Kakao.DOMAIN_URI + "/api/kakao/callback");
         parameters.set("code", code);
 
         ResponseEntity<JSONObject> apiResponse = postRequest(restTemplate, uri, parameters, null);


### PR DESCRIPTION

### 💡 다음 이슈를 해결했어요.
- 카카오 로그인 redirect_uri 수정 및 webflux 의존성 추가
<br><br>

### 💡 필요한 후속작업이 있어요.
- 서버에서 로그인 제대로 되는지 확인 필요
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
