### PR TITLE
[4] 로그인시 회원 정보 저장

### DIFF
--- a/backend/goodday/src/main/java/seeuthere/goodday/ControllerAdvice.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/ControllerAdvice.java
@@ -3,8 +3,8 @@ package seeuthere.goodday;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import seeuthere.goodday.exception.GoodDayException;
 import seeuthere.goodday.exception.ErrorResponse;
+import seeuthere.goodday.exception.GoodDayException;
 
 @RestControllerAdvice
 public class ControllerAdvice {
@@ -12,6 +12,6 @@ public class ControllerAdvice {
     @ExceptionHandler(GoodDayException.class)
     public ResponseEntity<ErrorResponse> handleGoodDayException(GoodDayException e) {
         return ResponseEntity.status(e.getStatus())
-            .body(new ErrorResponse(e.getMessage()));
+                .body(new ErrorResponse(e.getMessage()));
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/NaverController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/NaverController.java
@@ -12,21 +12,29 @@ import org.springframework.web.reactive.function.client.WebClient;
 import seeuthere.goodday.auth.domain.Naver;
 import seeuthere.goodday.auth.dto.ProfileDto;
 import seeuthere.goodday.auth.dto.TokenDto;
+import seeuthere.goodday.member.service.MemberService;
 import seeuthere.goodday.secret.SecretKey;
 
 import javax.servlet.http.HttpSession;
+
+import static seeuthere.goodday.auth.domain.Naver.NAVER_AUTH_URI;
 
 @Controller
 @RequestMapping("/api/naver")
 public class NaverController {
 
+    private final MemberService memberService;
+
+    public NaverController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
     @GetMapping("/oauth")
-    public String naverConnect(HttpSession session) {
+    public String naverConnect() {
         String state = Naver.generateState();
-        session.setAttribute("oauth_state", state);
 
         StringBuffer url = new StringBuffer();
-        url.append("https://nid.naver.com" + "/oauth2.0/authorize?");
+        url.append(NAVER_AUTH_URI + "/oauth2.0/authorize?");
         url.append("client_id=" + SecretKey.NAVER_API_KEY);
         url.append("&response_type=code");
         url.append("&redirect_uri=http://localhost:8080/api/naver/callback");
@@ -42,15 +50,16 @@ public class NaverController {
         TokenDto response = Naver.getAccessToken(code, state);
 
         session.setAttribute("access_token", response.getAccess_token());
-
-        return ResponseEntity.ok().body(Naver.getUserInfo(response.getAccess_token()));
+        ProfileDto profile = Naver.getUserInfo(response.getAccess_token());
+        memberService.add(profile);
+        return ResponseEntity.ok().body(profile);
     }
 
     @GetMapping("/logout")
     public String naverLogout(HttpSession session) {
         String accessToken = (String) session.getAttribute("access_token");
         WebClient webclient = WebClient.builder()
-                .baseUrl("https://nid.naver.com")
+                .baseUrl(NAVER_AUTH_URI)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/NaverController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/NaverController.java
@@ -1,6 +1,5 @@
 package seeuthere.goodday.auth.controller;
 
-import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +14,7 @@ import seeuthere.goodday.auth.dto.ProfileDto;
 import seeuthere.goodday.auth.dto.TokenDto;
 import seeuthere.goodday.secret.SecretKey;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.math.BigInteger;
-import java.security.SecureRandom;
 
 @Controller
 @RequestMapping("/api/naver")
@@ -41,8 +37,8 @@ public class NaverController {
 
     @RequestMapping(value = "/callback", method = {RequestMethod.GET, RequestMethod.POST}, produces = "application/json")
     public ResponseEntity<ProfileDto> naverLogin(@RequestParam(value = "code") String code,
-                                                  @RequestParam(value = "state") String state,
-                                                  HttpSession session) {
+                                                 @RequestParam(value = "state") String state,
+                                                 HttpSession session) {
         TokenDto response = Naver.getAccessToken(code, state);
 
         session.setAttribute("access_token", response.getAccess_token());

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
@@ -1,17 +1,12 @@
 package seeuthere.goodday.auth.domain;
 
 import org.json.simple.JSONObject;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 import seeuthere.goodday.auth.dto.ProfileDto;
 import seeuthere.goodday.secret.SecretKey;
 
-import java.net.URI;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -21,7 +16,8 @@ public class Kakao {
 
     public static final String KAKAO_HOST_URI = "https://kapi.kakao.com";
     public static final String KAKAO_AUTH_URI = "https://kauth.kakao.com";
-    public static final String DOMAIN_URI = "https://seeyouthere.o-r.kr";
+    // 도메인~~~
+    public static final String DOMAIN_URI = "http://localhost:8080";
 
     public static ProfileDto getKakaoUserInfo(String access_token) {
         WebClient webClient = WebClient.builder()
@@ -29,7 +25,7 @@ public class Kakao {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 
-        JSONObject response =  webClient.post()
+        JSONObject response = webClient.post()
                 .uri(uriBuilder -> uriBuilder.path("/v2/user/me").build())
                 .header("Authorization", "Bearer " + access_token)
                 .retrieve().bodyToMono(JSONObject.class).block();

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Kakao.java
@@ -16,8 +16,7 @@ public class Kakao {
 
     public static final String KAKAO_HOST_URI = "https://kapi.kakao.com";
     public static final String KAKAO_AUTH_URI = "https://kauth.kakao.com";
-    // 도메인~~~
-    public static final String DOMAIN_URI = "http://localhost:8080";
+    public static final String DOMAIN_URI = "https://seeyouthere.o-r.kr";
 
     public static ProfileDto getKakaoUserInfo(String access_token) {
         WebClient webClient = WebClient.builder()

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Naver.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Naver.java
@@ -16,8 +16,10 @@ import java.util.Map;
 
 public class Naver {
 
-    private Naver() {
+    public static String NAVER_HOST_URI = "https://openapi.naver.com";
+    public static String NAVER_AUTH_URI = "https://nid.naver.com";
 
+    private Naver() {
     }
 
     public static String generateState() {
@@ -27,7 +29,7 @@ public class Naver {
 
     public static TokenDto getAccessToken(String code, String state) {
         WebClient webclient = WebClient.builder()
-                .baseUrl("https://nid.naver.com")
+                .baseUrl(NAVER_AUTH_URI)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 
@@ -45,7 +47,7 @@ public class Naver {
 
     public static ProfileDto getUserInfo(String accessToken) {
         WebClient webclient = WebClient.builder()
-                .baseUrl("https://openapi.naver.com")
+                .baseUrl(NAVER_HOST_URI)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Naver.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/domain/Naver.java
@@ -1,5 +1,3 @@
-
-
 package seeuthere.goodday.auth.domain;
 
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/config/WebClientConfiguration.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/config/WebClientConfiguration.java
@@ -19,15 +19,15 @@ public class WebClientConfiguration {
         newMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
 
         ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
-            .codecs(configurer ->
-                configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(newMapper)))
-            .build();
+                .codecs(configurer ->
+                        configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(newMapper)))
+                .build();
 
         return WebClient.builder()
-            .baseUrl("https://dapi.kakao.com")
-            .exchangeStrategies(exchangeStrategies)
-            .defaultHeader("Authorization", "KakaoAK " + SecretKey.KAKAO_API_KEY)
-            .build();
+                .baseUrl("https://dapi.kakao.com")
+                .exchangeStrategies(exchangeStrategies)
+                .defaultHeader("Authorization", "KakaoAK " + SecretKey.KAKAO_API_KEY)
+                .build();
     }
 
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/exception/CustomException.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/exception/CustomException.java
@@ -3,5 +3,6 @@ package seeuthere.goodday.exception;
 public interface CustomException {
 
     String getMessage();
+
     int getStatus();
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/exception/ErrorResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/exception/ErrorResponse.java
@@ -5,7 +5,7 @@ public class ErrorResponse {
     private final String message;
 
     public ErrorResponse(String message) {
-        this.message= message;
+        this.message = message;
     }
 
     public String getMessage() {

--- a/backend/goodday/src/main/java/seeuthere/goodday/group/domain/History.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/group/domain/History.java
@@ -1,7 +1,8 @@
 package seeuthere.goodday.group.domain;
 
-import java.util.Date;
 import seeuthere.goodday.location.dto.Location;
+
+import java.util.Date;
 
 public class History {
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
@@ -1,6 +1,5 @@
 package seeuthere.goodday.location.controller;
 
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
 import seeuthere.goodday.location.service.LocationService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/location")
@@ -27,7 +28,7 @@ public class LocationController {
 
     @GetMapping("/address")
     public ResponseEntity<List<Document>> findAddress(@RequestParam double x,
-        @RequestParam double y) {
+                                                      @RequestParam double y) {
         List<Document> documents = locationService.findAddress(x, y);
         return ResponseEntity.ok(documents);
     }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/CoordinateRequester.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/CoordinateRequester.java
@@ -1,7 +1,5 @@
 package seeuthere.goodday.location.domain;
 
-import java.util.List;
-import java.util.Objects;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -9,6 +7,9 @@ import seeuthere.goodday.exception.GoodDayException;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.AxisResponse;
 import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+import java.util.List;
+import java.util.Objects;
 
 public class CoordinateRequester {
 
@@ -30,13 +31,13 @@ public class CoordinateRequester {
 
     private AxisResponse receivedAxisResponse(String address) {
         return webClient.get()
-            .uri(uriBuilder ->
-                uriBuilder.path(BASIC_URL)
-                    .queryParam("query", address)
-                    .build())
-            .accept(MediaType.APPLICATION_JSON)
-            .retrieve()
-            .bodyToMono(AxisResponse.class)
-            .block();
+                .uri(uriBuilder ->
+                        uriBuilder.path(BASIC_URL)
+                                .queryParam("query", address)
+                                .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(AxisResponse.class)
+                .block();
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/LocationRequester.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/LocationRequester.java
@@ -1,7 +1,5 @@
 package seeuthere.goodday.location.domain;
 
-import java.util.List;
-import java.util.Objects;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -9,6 +7,9 @@ import seeuthere.goodday.exception.GoodDayException;
 import seeuthere.goodday.location.dto.Document;
 import seeuthere.goodday.location.dto.LocationResponse;
 import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+import java.util.List;
+import java.util.Objects;
 
 public class LocationRequester {
 
@@ -31,15 +32,15 @@ public class LocationRequester {
 
     private LocationResponse receivedLocationResponse(double x, double y) {
         return webClient.get()
-            .uri(uriBuilder ->
-                uriBuilder.path(BASIC_URL)
-                    .queryParam("x", x)
-                    .queryParam("y", y)
-                    .build()
-            )
-            .accept(MediaType.APPLICATION_JSON)
-            .retrieve()
-            .bodyToMono(LocationResponse.class)
-            .block();
+                .uri(uriBuilder ->
+                        uriBuilder.path(BASIC_URL)
+                                .queryParam("x", x)
+                                .queryParam("y", y)
+                                .build()
+                )
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(LocationResponse.class)
+                .block();
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Address.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Address.java
@@ -18,7 +18,7 @@ public class Address {
     @Override
     public String toString() {
         return "Address{" +
-            "addressName='" + addressName + '\'' +
-            '}';
+                "addressName='" + addressName + '\'' +
+                '}';
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/AxisResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/AxisResponse.java
@@ -17,9 +17,9 @@ public class AxisResponse {
     @Override
     public String toString() {
         return "LocationResponse{" +
-            "meta=" + meta +
-            ", documents=" + documents +
-            '}';
+                "meta=" + meta +
+                ", documents=" + documents +
+                '}';
     }
 
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Document.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Document.java
@@ -60,15 +60,15 @@ public class Document {
     @Override
     public String toString() {
         return "Document{" +
-            "regionType='" + regionType + '\'' +
-            ", code='" + code + '\'' +
-            ", addressName='" + addressName + '\'' +
-            ", region1depthName='" + region1depthName + '\'' +
-            ", region2depthName='" + region2depthName + '\'' +
-            ", region3depthName='" + region3depthName + '\'' +
-            ", region4depthName='" + region4depthName + '\'' +
-            ", x=" + x +
-            ", y=" + y +
-            '}';
+                "regionType='" + regionType + '\'' +
+                ", code='" + code + '\'' +
+                ", addressName='" + addressName + '\'' +
+                ", region1depthName='" + region1depthName + '\'' +
+                ", region2depthName='" + region2depthName + '\'' +
+                ", region3depthName='" + region3depthName + '\'' +
+                ", region4depthName='" + region4depthName + '\'' +
+                ", x=" + x +
+                ", y=" + y +
+                '}';
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/LocationResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/LocationResponse.java
@@ -17,8 +17,8 @@ public class LocationResponse {
     @Override
     public String toString() {
         return "LocationResponse{" +
-            "meta=" + meta +
-            ", documents=" + documents +
-            '}';
+                "meta=" + meta +
+                ", documents=" + documents +
+                '}';
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Meta.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Meta.java
@@ -18,7 +18,7 @@ public class Meta {
     @Override
     public String toString() {
         return "Meta{" +
-            "totalCount=" + totalCount +
-            '}';
+                "totalCount=" + totalCount +
+                '}';
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
@@ -1,12 +1,13 @@
 package seeuthere.goodday.location.service;
 
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import seeuthere.goodday.location.domain.CoordinateRequester;
 import seeuthere.goodday.location.domain.LocationRequester;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
+
+import java.util.List;
 
 @Service
 public class LocationService {

--- a/backend/goodday/src/main/java/seeuthere/goodday/member/dao/MemberRepository.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/dao/MemberRepository.java
@@ -1,8 +1,13 @@
 package seeuthere.goodday.member.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import seeuthere.goodday.member.domain.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+@Transactional
+@Repository
+public interface MemberRepository extends JpaRepository<Member, String> {
 
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/member/domain/Member.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/domain/Member.java
@@ -13,7 +13,7 @@ public class Member extends Person {
     public Member() {
     }
 
-    public Member(Integer id, String name) {
+    public Member(String id, String name) {
         super(id, name);
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/member/domain/Person.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/domain/Person.java
@@ -8,7 +8,7 @@ import javax.persistence.*;
 public abstract class Person {
 
     @Id
-    private Integer id;
+    private String id;
 
     private String name;
 
@@ -17,12 +17,12 @@ public abstract class Person {
     public Person() {
     }
 
-    public Person(Integer id, String name) {
+    public Person(String id, String name) {
         this.id = id;
         this.name = name;
     }
 
-    public Integer getId() {
+    public String getId() {
         return id;
     }
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/member/service/MemberService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package seeuthere.goodday.member.service;
 
 import org.springframework.stereotype.Service;
+import seeuthere.goodday.auth.dto.ProfileDto;
 import seeuthere.goodday.member.dao.MemberRepository;
 import seeuthere.goodday.member.domain.Member;
 
@@ -15,11 +16,14 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
-    public void add(Member member) {
-        memberRepository.save(member);
+    public Member add(ProfileDto profile) {
+        if (find(profile.getId()).isEmpty()) {
+            return memberRepository.save(new Member(profile.getId(), profile.getNickname()));
+        }
+        return null;
     }
 
-    public Optional<Member> find(Integer id) {
+    public Optional<Member> find(String id) {
         return memberRepository.findById(id);
     }
 }

--- a/backend/goodday/src/main/resources/application-local.yml
+++ b/backend/goodday/src/main/resources/application-local.yml
@@ -11,9 +11,3 @@ spring:
 handlebars:
   suffix: .html
   enabled: true
-#  security 변동 생길 가능성 있음
-security:
-  jwt:
-    token:
-      secret-key: my_secret_is_secret
-      expire-length: 3600000

--- a/backend/goodday/src/main/resources/application-prod.yml
+++ b/backend/goodday/src/main/resources/application-prod.yml
@@ -14,8 +14,3 @@ spring:
 handlebars:
   suffix: .html
   enabled: true
-security:
-  jwt:
-    token:
-      secret-key: my_secret_is_secret
-      expire-length: 3600000

--- a/backend/goodday/src/main/resources/application-test.yml
+++ b/backend/goodday/src/main/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:subway
+    url: jdbc:h2:mem:seeyouthere
     username: sa
     password:
   h2:

--- a/backend/goodday/src/test/java/seeuthere/goodday/member/domain/MemberTest.java
+++ b/backend/goodday/src/test/java/seeuthere/goodday/member/domain/MemberTest.java
@@ -1,0 +1,38 @@
+package seeuthere.goodday.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import seeuthere.goodday.auth.dto.ProfileDto;
+import seeuthere.goodday.member.service.MemberService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DisplayName("멤버 관리를 한다.")
+@SpringBootTest
+class MemberTest {
+
+    @Autowired
+    private MemberService service;
+
+    @DisplayName("첫 로그인시 멤버를 저장한다.")
+    @Test
+    @Transactional
+    public void firstLoginSave() {
+        ProfileDto profile = new ProfileDto("12345", "영범허", "imageLink");
+        Member member = service.add(profile);
+        assertThat(service.find("12345").get()).isEqualTo(member);
+    }
+
+    @DisplayName("첫 로그인이 아닐 시 멤버를 저장하지 않는다.")
+    @Test
+    public void alreadyMemberNotSave() {
+        ProfileDto profile = new ProfileDto("12345", "영범허", "imageLink");
+        service.add(profile);
+        Member member = service.add(profile);
+        assertThat(member).isNull();
+    }
+}


### PR DESCRIPTION
<!--- 
# 뒤에 머지 후 close할 이슈번호를 적어주세요. 자동으로 close 됩니다.
--->
<strong>
Closes #26 
</strong>

### 💡 다음 이슈를 해결했어요.
- 첫 로그인시 DB에 회원정보 저장
- 이후 로그인시 로그인만 진행됨
- 회원 정보 저장 테스트 코드 작성

<br><br>

### 💡 필요한 후속작업이 있어요.
- h2 DB가 아닌 MariaDB에서 동작하는지 확인 필요

<br><br>



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
