### PR TITLE
[4] 중간 장소 도출 기능

### DIFF
--- a/backend/goodday/gradlew.bat
+++ b/backend/goodday/gradlew.bat
@@ -46,7 +46,7 @@ echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 echo.
 echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo point of your Java installation.
 
 goto fail
 
@@ -60,7 +60,7 @@ echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
 echo.
 echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo point of your Java installation.
 
 goto fail
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/GooddayApplication.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/GooddayApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class GoodDayApplication {
+public class GooddayApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(GoodDayApplication.class, args);
+        SpringApplication.run(GooddayApplication.class, args);
     }
 
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/group/domain/History.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/group/domain/History.java
@@ -1,7 +1,7 @@
 package seeuthere.goodday.group.domain;
 
 import java.util.Date;
-import seeuthere.goodday.location.dto.Location;
+import seeuthere.goodday.location.domain.Location;
 
 public class History {
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/group/domain/History.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/group/domain/History.java
@@ -1,11 +1,11 @@
 package seeuthere.goodday.group.domain;
 
 import java.util.Date;
-import seeuthere.goodday.location.domain.Location;
+import seeuthere.goodday.location.domain.Point;
 
 public class History {
 
     private Long id;
-    private Location location;
+    private Point point;
     private Date date;
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
 import seeuthere.goodday.location.service.LocationService;
 
@@ -25,8 +26,15 @@ public class LocationController {
     }
 
     @GetMapping("/address")
-    public ResponseEntity<List<Document>> findAddress(@RequestParam double x, @RequestParam double y) {
+    public ResponseEntity<List<Document>> findAddress(@RequestParam double x,
+        @RequestParam double y) {
         List<Document> documents = locationService.findAddress(x, y);
         return ResponseEntity.ok(documents);
+    }
+
+    @GetMapping("/coordinate")
+    public ResponseEntity<List<AxisDocument>> findAxis(@RequestParam String address) {
+        List<AxisDocument> axisDocuments = locationService.findAxis(address);
+        return ResponseEntity.ok(axisDocuments);
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
@@ -3,11 +3,13 @@ package seeuthere.goodday.location.controller;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
+import seeuthere.goodday.location.dto.UtilityDocument;
 import seeuthere.goodday.location.service.LocationService;
 
 @RestController
@@ -37,4 +39,19 @@ public class LocationController {
         List<AxisDocument> axisDocuments = locationService.findAxis(address);
         return ResponseEntity.ok(axisDocuments);
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<UtilityDocument>> findBasicUtility(@RequestParam String keyword) {
+        List<UtilityDocument> documents = locationService.findSearch(keyword);
+        return ResponseEntity.ok(documents);
+    }
+
+    @GetMapping("/utility/{category}")
+    public ResponseEntity<List<UtilityDocument>> findUtility(@PathVariable String category,
+        @RequestParam double x, @RequestParam double y) {
+        List<UtilityDocument> documents = locationService.findUtility(category, x, y);
+        return ResponseEntity.ok(documents);
+    }
 }
+
+

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
@@ -9,10 +9,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import seeuthere.goodday.location.dto.AxisDocument;
+import seeuthere.goodday.location.domain.Location;
 import seeuthere.goodday.location.dto.Document;
 import seeuthere.goodday.location.dto.LocationsRequest;
 import seeuthere.goodday.location.dto.MiddlePointResponse;
+import seeuthere.goodday.location.dto.Response;
 import seeuthere.goodday.location.dto.UtilityDocument;
 import seeuthere.goodday.location.service.LocationService;
 
@@ -27,33 +28,35 @@ public class LocationController {
     }
 
     @GetMapping("/address")
-    public ResponseEntity<List<Document>> findAddress(@RequestParam double x,
+    public ResponseEntity<Response<Document>> findAddress(@RequestParam double x,
         @RequestParam double y) {
         List<Document> documents = locationService.findAddress(x, y);
-        return ResponseEntity.ok(documents);
+        return ResponseEntity.ok(new Response<>(documents));
     }
 
     @GetMapping("/coordinate")
-    public ResponseEntity<List<AxisDocument>> findAxis(@RequestParam String address) {
-        List<AxisDocument> axisDocuments = locationService.findAxis(address);
-        return ResponseEntity.ok(axisDocuments);
+    public ResponseEntity<Response<Location>> findAxis(@RequestParam String address) {
+        List<Location> locations = locationService.findAxis(address);
+        return ResponseEntity.ok(new Response<>(locations));
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<UtilityDocument>> findBasicUtility(@RequestParam String keyword) {
+    public ResponseEntity<Response<UtilityDocument>> findBasicUtility(
+        @RequestParam String keyword) {
         List<UtilityDocument> documents = locationService.findSearch(keyword);
-        return ResponseEntity.ok(documents);
+        return ResponseEntity.ok(new Response<>(documents));
     }
 
     @GetMapping("/utility/{category}")
-    public ResponseEntity<List<UtilityDocument>> findUtility(@PathVariable String category,
+    public ResponseEntity<Response<UtilityDocument>> findUtility(@PathVariable String category,
         @RequestParam double x, @RequestParam double y) {
         List<UtilityDocument> documents = locationService.findUtility(category, x, y);
-        return ResponseEntity.ok(documents);
+        return ResponseEntity.ok(new Response<>(documents));
     }
 
     @PostMapping("/middlePoint")
-    public ResponseEntity<MiddlePointResponse> findMiddlePoint(@RequestBody LocationsRequest locationsRequest) {
+    public ResponseEntity<MiddlePointResponse> findMiddlePoint(
+        @RequestBody LocationsRequest locationsRequest) {
         MiddlePointResponse middlePointResponse = locationService.findMiddlePoint(locationsRequest);
         return ResponseEntity.ok(middlePointResponse);
     }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/controller/LocationController.java
@@ -4,22 +4,21 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
+import seeuthere.goodday.location.dto.LocationsRequest;
+import seeuthere.goodday.location.dto.MiddlePointResponse;
 import seeuthere.goodday.location.dto.UtilityDocument;
 import seeuthere.goodday.location.service.LocationService;
 
 @RestController
 @RequestMapping("/api/location")
 public class LocationController {
-
-    /*
-        중간지점 찾기
-        request 를 body 로 받는게 좋을것 같은데, 의논 필요
-    */
 
     private final LocationService locationService;
 
@@ -51,6 +50,12 @@ public class LocationController {
         @RequestParam double x, @RequestParam double y) {
         List<UtilityDocument> documents = locationService.findUtility(category, x, y);
         return ResponseEntity.ok(documents);
+    }
+
+    @PostMapping("/middlePoint")
+    public ResponseEntity<MiddlePointResponse> findMiddlePoint(@RequestBody LocationsRequest locationsRequest) {
+        MiddlePointResponse middlePointResponse = locationService.findMiddlePoint(locationsRequest);
+        return ResponseEntity.ok(middlePointResponse);
     }
 }
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/AxisKeywordCombiner.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/AxisKeywordCombiner.java
@@ -1,0 +1,74 @@
+package seeuthere.goodday.location.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import seeuthere.goodday.exception.GoodDayException;
+import seeuthere.goodday.location.dto.AxisDocument;
+import seeuthere.goodday.location.dto.UtilityDocument;
+import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+public class AxisKeywordCombiner {
+
+    private final List<Location> locations;
+
+    public AxisKeywordCombiner(List<Location> locations) {
+        this.locations = locations;
+    }
+
+    public List<Location> getLocations() {
+        return new ArrayList<>(locations);
+    }
+
+    public static AxisKeywordCombiner valueOf(List<AxisDocument> axisDocuments,
+        List<UtilityDocument> utilityDocuments) {
+        List<Location> locations = new ArrayList<>();
+        isNull(axisDocuments, utilityDocuments);
+        axisProcess(locations, axisDocuments);
+        utilityProcess(locations, utilityDocuments);
+        return new AxisKeywordCombiner(locations);
+    }
+
+    private static void axisProcess(List<Location> locations, List<AxisDocument> axisDocuments) {
+        for (AxisDocument axisDocument : axisDocuments) {
+            locations.add(
+                new Location.Builder()
+                    .x(axisDocument.getX())
+                    .y(axisDocument.getY())
+                    .address(axisDocument.getAddress())
+                    .roadAddress(axisDocument.getRoadAddress())
+                    .name(validAddress(axisDocument))
+                    .build()
+            );
+        }
+    }
+
+    private static void utilityProcess(List<Location> locations,
+        List<UtilityDocument> utilityDocuments) {
+        for (UtilityDocument utilityDocument : utilityDocuments) {
+            locations.add(
+                new Location.Builder()
+                    .x(utilityDocument.getX())
+                    .y(utilityDocument.getY())
+                    .address(utilityDocument.getAddressName())
+                    .roadAddress(utilityDocument.getRoadAddressName())
+                    .name(utilityDocument.getPlaceName())
+                    .build()
+            );
+        }
+    }
+
+    private static void isNull(List<AxisDocument> axisDocuments,
+        List<UtilityDocument> utilityDocuments) {
+        if (Objects.isNull(axisDocuments) && Objects.isNull(utilityDocuments)) {
+            throw new GoodDayException(LocationExceptionSet.INVALID_LOCATION);
+        }
+    }
+
+    private static String validAddress(AxisDocument axisDocument) {
+        if (Objects.nonNull(axisDocument.getAddress())) {
+            return axisDocument.getAddress().getAddressName();
+        }
+        return axisDocument.getRoadAddress().getAddressName();
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/CoordinateRequester.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/CoordinateRequester.java
@@ -1,0 +1,42 @@
+package seeuthere.goodday.location.domain;
+
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import seeuthere.goodday.exception.GoodDayException;
+import seeuthere.goodday.location.dto.AxisDocument;
+import seeuthere.goodday.location.dto.AxisResponse;
+import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+public class CoordinateRequester {
+
+    private static final String BASIC_URL = "/v2/local/search/address.json";
+    private final WebClient webClient;
+
+    public CoordinateRequester(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public List<AxisDocument> requestCoordinate(String address) {
+        try {
+            AxisResponse axisResponse = receivedAxisResponse(address);
+            return Objects.requireNonNull(axisResponse).getDocuments();
+        } catch (WebClientResponseException e) {
+            throw new GoodDayException(LocationExceptionSet.INVALID_LOCATION);
+        }
+    }
+
+    private AxisResponse receivedAxisResponse(String address) {
+        return webClient.get()
+            .uri(uriBuilder ->
+                uriBuilder.path(BASIC_URL)
+                    .queryParam("query", address)
+                    .build())
+            .accept(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(AxisResponse.class)
+            .block();
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/Location.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/Location.java
@@ -1,16 +1,22 @@
 package seeuthere.goodday.location.domain;
 
+import java.util.Objects;
+import seeuthere.goodday.location.dto.Address;
+
 public class Location {
 
-    private double x;
-    private double y;
+    private final double x;
+    private final double y;
+    private final String address;
+    private final String roadAddress;
+    private final String name;
 
-    public Location() {
-    }
-
-    public Location(double x, double y) {
-        this.x = x;
-        this.y = y;
+    private Location(Builder builder) {
+        x = builder.x;
+        y = builder.y;
+        address = builder.address;
+        roadAddress = builder.roadAddress;
+        name = builder.name;
     }
 
     public double getX() {
@@ -19,5 +25,72 @@ public class Location {
 
     public double getY() {
         return y;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getRoadAddress() {
+        return roadAddress;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static class Builder {
+
+        private double x = 0;
+        private double y = 0;
+        private String address = "";
+        private String roadAddress = "";
+        private String name = "";
+
+        public Builder() {
+        }
+
+        public Builder x(double x) {
+            this.x = x;
+            return this;
+        }
+
+        public Builder y(double y) {
+            this.y = y;
+            return this;
+        }
+
+        public Builder address(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public Builder address(Address address) {
+            if (Objects.nonNull(address)) {
+                this.address = address.getAddressName();
+            }
+            return this;
+        }
+
+        public Builder roadAddress(String roadAddress) {
+            this.roadAddress = roadAddress;
+            return this;
+        }
+
+        public Builder roadAddress(Address roadAddress) {
+            if (Objects.nonNull(roadAddress)) {
+                this.roadAddress = roadAddress.getAddressName();
+            }
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Location build() {
+            return new Location(this);
+        }
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/Location.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/Location.java
@@ -1,0 +1,23 @@
+package seeuthere.goodday.location.domain;
+
+public class Location {
+
+    private double x;
+    private double y;
+
+    public Location() {
+    }
+
+    public Location(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/LocationRequester.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/LocationRequester.java
@@ -12,26 +12,34 @@ import seeuthere.goodday.location.exception.LocationExceptionSet;
 
 public class LocationRequester {
 
-    private static final String BASIC_URL = "/v2/local/geo/coord2regioncode.json?x=%s&y=%s";
+    private static final String BASIC_URL = "/v2/local/geo/coord2regioncode.json";
     private final WebClient webClient;
 
     public LocationRequester(WebClient webClient) {
         this.webClient = webClient;
     }
 
-    public List<Document> requestAddress(double x, double y){
+    public List<Document> requestAddress(double x, double y) {
         try {
-            String url = String.format(BASIC_URL, x, y);
-            LocationResponse locationResponse = webClient.get()
-                .uri(url)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(LocationResponse.class)
-                .block();
+            LocationResponse locationResponse = receivedLocationResponse(x, y);
 
             return Objects.requireNonNull(locationResponse).getDocuments();
         } catch (WebClientResponseException e) {
             throw new GoodDayException(LocationExceptionSet.INVALID_LOCATION);
         }
+    }
+
+    private LocationResponse receivedLocationResponse(double x, double y) {
+        return webClient.get()
+            .uri(uriBuilder ->
+                uriBuilder.path(BASIC_URL)
+                    .queryParam("x", x)
+                    .queryParam("y", y)
+                    .build()
+            )
+            .accept(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(LocationResponse.class)
+            .block();
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/MiddlePoint.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/MiddlePoint.java
@@ -1,0 +1,46 @@
+package seeuthere.goodday.location.domain;
+
+import java.util.List;
+import java.util.Objects;
+import seeuthere.goodday.exception.GoodDayException;
+import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+public class MiddlePoint {
+
+    private final double x;
+    private final double y;
+
+    public MiddlePoint(Location location) {
+        this.x = location.getX();
+        this.y = location.getY();
+    }
+
+    public static MiddlePoint valueOf(List<Location> locations) {
+        validation(locations);
+        return new MiddlePoint(calculation(locations));
+    }
+
+    private static void validation(List<Location> locations) {
+        if (Objects.isNull(locations) || locations.size() <= 1) {
+            throw new GoodDayException(LocationExceptionSet.NOT_ENOUGH_LOCATION);
+        }
+    }
+
+    private static Location calculation(List<Location> locations) {
+        double sumX = 0;
+        double sumY = 0;
+        for (Location location : locations) {
+            sumX += location.getX();
+            sumY += location.getY();
+        }
+        return new Location(sumX / locations.size(), sumY / locations.size());
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/MiddlePoint.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/MiddlePoint.java
@@ -10,30 +10,30 @@ public class MiddlePoint {
     private final double x;
     private final double y;
 
-    public MiddlePoint(Location location) {
-        this.x = location.getX();
-        this.y = location.getY();
+    public MiddlePoint(Point point) {
+        this.x = point.getX();
+        this.y = point.getY();
     }
 
-    public static MiddlePoint valueOf(List<Location> locations) {
-        validation(locations);
-        return new MiddlePoint(calculation(locations));
+    public static MiddlePoint valueOf(List<Point> points) {
+        validation(points);
+        return new MiddlePoint(calculation(points));
     }
 
-    private static void validation(List<Location> locations) {
-        if (Objects.isNull(locations) || locations.size() <= 1) {
+    private static void validation(List<Point> points) {
+        if (Objects.isNull(points) || points.size() <= 1) {
             throw new GoodDayException(LocationExceptionSet.NOT_ENOUGH_LOCATION);
         }
     }
 
-    private static Location calculation(List<Location> locations) {
+    private static Point calculation(List<Point> points) {
         double sumX = 0;
         double sumY = 0;
-        for (Location location : locations) {
-            sumX += location.getX();
-            sumY += location.getY();
+        for (Point point : points) {
+            sumX += point.getX();
+            sumY += point.getY();
         }
-        return new Location(sumX / locations.size(), sumY / locations.size());
+        return new Point(sumX / points.size(), sumY / points.size());
     }
 
     public double getX() {

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/Point.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/Point.java
@@ -1,0 +1,23 @@
+package seeuthere.goodday.location.domain;
+
+public class Point {
+
+    private double x;
+    private double y;
+
+    public Point() {
+    }
+
+    public Point(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/SearchRequester.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/SearchRequester.java
@@ -1,0 +1,43 @@
+package seeuthere.goodday.location.domain;
+
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import seeuthere.goodday.exception.GoodDayException;
+import seeuthere.goodday.location.dto.UtilityDocument;
+import seeuthere.goodday.location.dto.UtilityResponse;
+import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+public class SearchRequester {
+
+    private static final String BASIC_URL = "/v2/local/search/keyword.json";
+    private final WebClient webClient;
+
+    public SearchRequester(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public List<UtilityDocument> requestSearch(String keyword) {
+        try {
+            UtilityResponse utilityResponse = receivedSearchResponse(keyword);
+            return Objects.requireNonNull(utilityResponse).getDocuments();
+        } catch (WebClientResponseException e) {
+            throw new GoodDayException(LocationExceptionSet.INVALID_LOCATION);
+        }
+    }
+
+    private UtilityResponse receivedSearchResponse(String keyword) {
+        return webClient.get()
+            .uri(uriBuilder ->
+                uriBuilder.path(BASIC_URL)
+                    .queryParam("query", keyword)
+                    .build()
+            )
+            .accept(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(UtilityResponse.class)
+            .block();
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/domain/UtilityRequester.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/domain/UtilityRequester.java
@@ -1,0 +1,48 @@
+package seeuthere.goodday.location.domain;
+
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import seeuthere.goodday.exception.GoodDayException;
+import seeuthere.goodday.location.dto.UtilityDocument;
+import seeuthere.goodday.location.dto.UtilityResponse;
+import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+public class UtilityRequester {
+
+    private static final String BASIC_URL = "/v2/local/search/category.json";
+    private static final int BASIC_DISTANCE = 1000;
+    private final WebClient webClient;
+
+    public UtilityRequester(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public List<UtilityDocument> requestUtility(String categoryCode, double x, double y) {
+        try {
+            UtilityResponse utilityResponse = receivedUtilityResponse(categoryCode, x, y);
+            return Objects.requireNonNull(utilityResponse).getDocuments();
+        } catch (WebClientResponseException e) {
+            throw new GoodDayException(LocationExceptionSet.INVALID_LOCATION);
+        }
+    }
+
+    private UtilityResponse receivedUtilityResponse(String categoryCode, double x, double y) {
+        return webClient.get()
+            .uri(uriBuilder ->
+                uriBuilder.path(BASIC_URL)
+                    .queryParam("x", x)
+                    .queryParam("y", y)
+                    .queryParam("category_group_code", categoryCode)
+                    .queryParam("radius", BASIC_DISTANCE)
+                    .queryParam("sort", "distance")
+                    .build()
+            )
+            .accept(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(UtilityResponse.class)
+            .block();
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Address.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Address.java
@@ -1,0 +1,24 @@
+package seeuthere.goodday.location.dto;
+
+public class Address {
+
+    private String addressName;
+
+    public Address() {
+    }
+
+    public Address(String addressName) {
+        this.addressName = addressName;
+    }
+
+    public String getAddressName() {
+        return addressName;
+    }
+
+    @Override
+    public String toString() {
+        return "Address{" +
+            "addressName='" + addressName + '\'' +
+            '}';
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/AxisDocument.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/AxisDocument.java
@@ -1,0 +1,29 @@
+package seeuthere.goodday.location.dto;
+
+public class AxisDocument {
+
+    private double x;
+    private double y;
+    private Address address;
+    private Address roadAddress;
+
+    public AxisDocument() {
+
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public Address getRoadAddress() {
+        return roadAddress;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/AxisResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/AxisResponse.java
@@ -2,15 +2,15 @@ package seeuthere.goodday.location.dto;
 
 import java.util.List;
 
-public class LocationResponse {
+public class AxisResponse {
 
     private Meta meta;
-    private List<Document> documents;
+    private List<AxisDocument> documents;
 
-    public LocationResponse() {
+    public AxisResponse() {
     }
 
-    public List<Document> getDocuments() {
+    public List<AxisDocument> getDocuments() {
         return documents;
     }
 
@@ -21,4 +21,5 @@ public class LocationResponse {
             ", documents=" + documents +
             '}';
     }
+
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Location.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Location.java
@@ -1,7 +1,0 @@
-package seeuthere.goodday.location.dto;
-
-public class Location {
-
-    private double latitude;
-    private double longitude;
-}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/LocationRequest.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/LocationRequest.java
@@ -1,0 +1,23 @@
+package seeuthere.goodday.location.dto;
+
+public class LocationRequest {
+
+    private double x;
+    private double y;
+
+    public LocationRequest() {
+    }
+
+    public LocationRequest(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/LocationsRequest.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/LocationsRequest.java
@@ -1,0 +1,17 @@
+package seeuthere.goodday.location.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class LocationsRequest {
+
+    @JsonProperty("locations")
+    private List<LocationRequest> locationRequests;
+
+    public LocationsRequest() {
+    }
+
+    public List<LocationRequest> getLocationRequests() {
+        return locationRequests;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Meta.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Meta.java
@@ -4,7 +4,6 @@ public class Meta {
 
     int totalCount;
 
-
     public Meta() {
     }
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/MiddlePointResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/MiddlePointResponse.java
@@ -1,0 +1,20 @@
+package seeuthere.goodday.location.dto;
+
+public class MiddlePointResponse {
+
+    private final double x;
+    private final double y;
+
+    public MiddlePointResponse(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Response.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/Response.java
@@ -1,0 +1,16 @@
+package seeuthere.goodday.location.dto;
+
+import java.util.List;
+
+public class Response<T> {
+
+    List<T> data;
+
+    public Response(List<T> data) {
+        this.data = data;
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/UtilityDocument.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/UtilityDocument.java
@@ -4,9 +4,10 @@ public class UtilityDocument {
 
     private String placeName;
     private String distance;
+    private String addressName;
     private String roadAddressName;
-    private String x;
-    private String y;
+    private double x;
+    private double y;
 
     public UtilityDocument() {
 
@@ -20,15 +21,19 @@ public class UtilityDocument {
         return distance;
     }
 
+    public String getAddressName() {
+        return addressName;
+    }
+
     public String getRoadAddressName() {
         return roadAddressName;
     }
 
-    public String getX() {
+    public double getX() {
         return x;
     }
 
-    public String getY() {
+    public double getY() {
         return y;
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/UtilityDocument.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/UtilityDocument.java
@@ -1,0 +1,34 @@
+package seeuthere.goodday.location.dto;
+
+public class UtilityDocument {
+
+    private String placeName;
+    private String distance;
+    private String roadAddressName;
+    private String x;
+    private String y;
+
+    public UtilityDocument() {
+
+    }
+
+    public String getPlaceName() {
+        return placeName;
+    }
+
+    public String getDistance() {
+        return distance;
+    }
+
+    public String getRoadAddressName() {
+        return roadAddressName;
+    }
+
+    public String getX() {
+        return x;
+    }
+
+    public String getY() {
+        return y;
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/dto/UtilityResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/dto/UtilityResponse.java
@@ -1,0 +1,24 @@
+package seeuthere.goodday.location.dto;
+
+import java.util.List;
+
+public class UtilityResponse {
+
+    private Meta meta;
+    private List<UtilityDocument> documents;
+
+    public UtilityResponse() {
+    }
+
+    public List<UtilityDocument> getDocuments() {
+        return documents;
+    }
+
+    @Override
+    public String toString() {
+        return "LocationResponse{" +
+            "meta=" + meta +
+            ", documents=" + documents +
+            '}';
+    }
+}

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/exception/LocationExceptionSet.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/exception/LocationExceptionSet.java
@@ -5,7 +5,8 @@ import seeuthere.goodday.exception.CustomException;
 
 public enum LocationExceptionSet implements CustomException {
 
-    INVALID_LOCATION("위치를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST.value());
+    INVALID_LOCATION("위치를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
+    NOT_FOUND_CATEGORY("해당 카테고리는 존재하지 않습니다.", HttpStatus.BAD_REQUEST.value());
 
     private final String message;
     private final int status;

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/exception/LocationExceptionSet.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/exception/LocationExceptionSet.java
@@ -6,7 +6,8 @@ import seeuthere.goodday.exception.CustomException;
 public enum LocationExceptionSet implements CustomException {
 
     INVALID_LOCATION("위치를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
-    NOT_FOUND_CATEGORY("해당 카테고리는 존재하지 않습니다.", HttpStatus.BAD_REQUEST.value());
+    NOT_FOUND_CATEGORY("해당 카테고리는 존재하지 않습니다.", HttpStatus.BAD_REQUEST.value()),
+    NOT_ENOUGH_LOCATION("중간 지점을 계산하기에는 장소 수가 적습니다.", HttpStatus.BAD_REQUEST.value());
 
     private final String message;
     private final int status;

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import seeuthere.goodday.location.domain.AxisKeywordCombiner;
 import seeuthere.goodday.location.domain.CoordinateRequester;
 import seeuthere.goodday.location.domain.Location;
 import seeuthere.goodday.location.domain.LocationRequester;
 import seeuthere.goodday.location.domain.MiddlePoint;
+import seeuthere.goodday.location.domain.Point;
 import seeuthere.goodday.location.domain.SearchRequester;
 import seeuthere.goodday.location.domain.UtilityRequester;
 import seeuthere.goodday.location.dto.AxisDocument;
@@ -33,10 +35,16 @@ public class LocationService {
         return locationRequester.requestAddress(x, y);
     }
 
-    public List<AxisDocument> findAxis(String address) {
-
+    public List<Location> findAxis(String address) {
         CoordinateRequester coordinateRequester = new CoordinateRequester(webClient);
-        return coordinateRequester.requestCoordinate(address);
+        SearchRequester searchRequester = new SearchRequester(webClient);
+
+        List<AxisDocument> exactAddressResult = coordinateRequester.requestCoordinate(address);
+        List<UtilityDocument> keyWordResult = searchRequester.requestSearch(address);
+
+        AxisKeywordCombiner axisKeywordCombiner = AxisKeywordCombiner.valueOf(exactAddressResult,
+            keyWordResult);
+        return axisKeywordCombiner.getLocations();
     }
 
     public List<UtilityDocument> findUtility(String category, double x, double y) {
@@ -47,19 +55,18 @@ public class LocationService {
     }
 
     public List<UtilityDocument> findSearch(String keyword) {
-
         SearchRequester searchRequester = new SearchRequester(webClient);
         return searchRequester.requestSearch(keyword);
     }
 
     public MiddlePointResponse findMiddlePoint(LocationsRequest locationsRequest) {
-        List<Location> locations = new ArrayList<>();
+        List<Point> points = new ArrayList<>();
 
         for (LocationRequest locationRequest : locationsRequest.getLocationRequests()) {
-            locations.add(new Location(locationRequest.getX(), locationRequest.getY()));
+            points.add(new Point(locationRequest.getX(), locationRequest.getY()));
         }
 
-        MiddlePoint middlePoint = MiddlePoint.valueOf(locations);
+        MiddlePoint middlePoint = MiddlePoint.valueOf(points);
         return new MiddlePointResponse(middlePoint.getX(), middlePoint.getY());
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
@@ -1,14 +1,20 @@
 package seeuthere.goodday.location.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import seeuthere.goodday.location.domain.CoordinateRequester;
+import seeuthere.goodday.location.domain.Location;
 import seeuthere.goodday.location.domain.LocationRequester;
+import seeuthere.goodday.location.domain.MiddlePoint;
 import seeuthere.goodday.location.domain.SearchRequester;
 import seeuthere.goodday.location.domain.UtilityRequester;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
+import seeuthere.goodday.location.dto.LocationRequest;
+import seeuthere.goodday.location.dto.LocationsRequest;
+import seeuthere.goodday.location.dto.MiddlePointResponse;
 import seeuthere.goodday.location.dto.UtilityDocument;
 import seeuthere.goodday.location.util.LocationCategory;
 
@@ -44,5 +50,16 @@ public class LocationService {
 
         SearchRequester searchRequester = new SearchRequester(webClient);
         return searchRequester.requestSearch(keyword);
+    }
+
+    public MiddlePointResponse findMiddlePoint(LocationsRequest locationsRequest) {
+        List<Location> locations = new ArrayList<>();
+
+        for (LocationRequest locationRequest : locationsRequest.getLocationRequests()) {
+            locations.add(new Location(locationRequest.getX(), locationRequest.getY()));
+        }
+
+        MiddlePoint middlePoint = MiddlePoint.valueOf(locations);
+        return new MiddlePointResponse(middlePoint.getX(), middlePoint.getY());
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
@@ -5,8 +5,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import seeuthere.goodday.location.domain.CoordinateRequester;
 import seeuthere.goodday.location.domain.LocationRequester;
+import seeuthere.goodday.location.domain.SearchRequester;
+import seeuthere.goodday.location.domain.UtilityRequester;
 import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
+import seeuthere.goodday.location.dto.UtilityDocument;
+import seeuthere.goodday.location.util.LocationCategory;
 
 @Service
 public class LocationService {
@@ -27,5 +31,18 @@ public class LocationService {
 
         CoordinateRequester coordinateRequester = new CoordinateRequester(webClient);
         return coordinateRequester.requestCoordinate(address);
+    }
+
+    public List<UtilityDocument> findUtility(String category, double x, double y) {
+
+        String categoryCode = LocationCategory.translatedCode(category);
+        UtilityRequester utilityRequester = new UtilityRequester(webClient);
+        return utilityRequester.requestUtility(categoryCode, x, y);
+    }
+
+    public List<UtilityDocument> findSearch(String keyword) {
+
+        SearchRequester searchRequester = new SearchRequester(webClient);
+        return searchRequester.requestSearch(keyword);
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/service/LocationService.java
@@ -3,11 +3,14 @@ package seeuthere.goodday.location.service;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import seeuthere.goodday.location.domain.CoordinateRequester;
 import seeuthere.goodday.location.domain.LocationRequester;
+import seeuthere.goodday.location.dto.AxisDocument;
 import seeuthere.goodday.location.dto.Document;
 
 @Service
 public class LocationService {
+
     private final WebClient webClient;
 
     public LocationService(WebClient webClient) {
@@ -18,5 +21,11 @@ public class LocationService {
 
         LocationRequester locationRequester = new LocationRequester(webClient);
         return locationRequester.requestAddress(x, y);
+    }
+
+    public List<AxisDocument> findAxis(String address) {
+
+        CoordinateRequester coordinateRequester = new CoordinateRequester(webClient);
+        return coordinateRequester.requestCoordinate(address);
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/location/util/LocationCategory.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/location/util/LocationCategory.java
@@ -1,0 +1,60 @@
+package seeuthere.goodday.location.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import seeuthere.goodday.exception.GoodDayException;
+import seeuthere.goodday.location.exception.LocationExceptionSet;
+
+public enum LocationCategory {
+
+    MT1("MT1", "대형마트"),
+    CS2("CS2", "편의점"),
+    PS3("PS3", "어린이집,유치원"),
+    SC4("SC4", "학교"),
+    AC5("AC5", "학원"),
+    PK6("PK5", "주차장"),
+    OL7("OL7", "주유소,충전소"),
+    SW8("SW8", "지하철역"),
+    BK9("BK9", "은행"),
+    CT1("CT1", "문화시설"),
+    AG2("AG2", "중개업소"),
+    PO3("PO3", "공공기관"),
+    AT4("AT4", "관광명소"),
+    AD5("AD5", "숙박"),
+    FD6("FD6", "음식점"),
+    CE7("CE7", "카페"),
+    HP8("HP8", "병원"),
+    PM9("PM9", "약국");
+
+    private static final Map<String, LocationCategory> categoryMap = new HashMap<>();
+
+    static {
+        LocationCategory[] values = LocationCategory.values();
+        for (LocationCategory value : values) {
+            categoryMap.put(value.getDescription(), value);
+        }
+    }
+
+    private final String code;
+    private final String description;
+
+    LocationCategory(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static String translatedCode(String description) {
+        if (!categoryMap.containsKey(description)) {
+            throw new GoodDayException(LocationExceptionSet.NOT_FOUND_CATEGORY);
+        }
+        return categoryMap.get(description).getCode();
+    }
+}


### PR DESCRIPTION
<!--- 
# 뒤에 머지 후 close할 이슈번호를 적어주세요. 자동으로 close 됩니다.
--->
<strong>
Closes #41
</strong>

### 💡 다음 이슈를 해결했어요.
-  중간 지점을 계산하는 로직 추가

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- 도로명 주소와 동 주소 병행 표기
- 주소로 검색 시에 null 값이 나오는 부분들 처리 
- Response에 data로 한번 감싸서 송출

<br><br>

### 💡 필요한 후속작업이 있어요.
- Domain에서의 DTO, Entity 경계 확실히 만들기
- WebClient Lazy Loading 문제 해결

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
