### PR TITLE
fix: 배포 시 react-refresh 실행되는 문제 해결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "여기서만나(프론트엔드)",
   "main": "index.js",
   "scripts": {
-    "start": "webpack serve",
+    "start": "webpack serve --mode=development",
     "build": "webpack --mode=production"
   },
   "contributors": [

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -4,8 +4,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
-module.exports = {
-  mode: 'development',
+const config = ({ isDev }) => ({
+  mode: isDev ? 'development' : 'production',
   resolve: {
     extensions: ['.js', '.jsx'],
   },
@@ -31,11 +31,11 @@ module.exports = {
         exclude: '/node_modules',
         loader: 'babel-loader',
         options: {
-          plugins: ['react-refresh/babel'],
           presets: [
             ['@babel/preset-env', { targets: { esmodules: true, browsers: ['last 2 versions'] } }],
             '@babel/preset-react',
           ],
+          plugins: [isDev && 'react-refresh/babel'].filter(Boolean),
         },
       },
     ],
@@ -57,4 +57,6 @@ module.exports = {
     open: true,
     hot: true,
   },
-};
+});
+
+module.exports = (env, argv) => config({ isDev: argv.mode === 'development' });


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 개발환경에서만 실행되어야 할 react-refresh 패키지가 배포환경에서도 실행되는 문제를 해결했습니다.

![image](https://user-images.githubusercontent.com/60066472/126025166-ebd4ba8e-4a2e-442c-ba02-5f6e020e065a.png)

<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- [react-refresh 웹팩 플러그인 깃허브 이슈](https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/397)
- [웹팩 공식홈페이지](https://webpack.js.org/configuration/mode/#usage)

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.

p.s. `npm run build`로 로컬에서도 빌드 결과를 확인할 수 있는 것을 이제야 지각했네요 🥲 앞으로는 꼭 확인하고 PR 올리겠습니다! @hybeom0720 감사합니다 🙏 !!