### PR TITLE
[hotfix] 기존 회원로그인시 회원 memberId 반환하도록 수정

### DIFF
--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/KakaoController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/KakaoController.java
@@ -47,7 +47,7 @@ public class KakaoController {
         RequestMethod.POST})
     public ResponseEntity<ProfileTokenResponse> kakaoLogin(@RequestParam("code") String code) {
         ProfileResponse profile = kakaoService.getProfileWithToken(code);
-        memberService.add(profile);
-        return ResponseEntity.ok().body(authService.createToken(profile));
+
+        return ResponseEntity.ok().body(authService.createToken(memberService.add(profile)));
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/NaverController.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/controller/NaverController.java
@@ -51,7 +51,6 @@ public class NaverController {
     public ResponseEntity<ProfileTokenResponse> naverLogin(@RequestParam(value = "code") String code,
         @RequestParam(value = "state") String state) {
         ProfileResponse profile = naverService.getProfileWithToken(code, state);
-        memberService.add(profile);
-        return ResponseEntity.ok().body(authService.createToken(profile));
+        return ResponseEntity.ok().body(authService.createToken(memberService.add(profile)));
     }
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/dto/ProfileTokenResponse.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/dto/ProfileTokenResponse.java
@@ -1,5 +1,7 @@
 package seeuthere.goodday.auth.dto;
 
+import seeuthere.goodday.member.domain.Member;
+
 public class ProfileTokenResponse {
 
     private String id;
@@ -8,11 +10,11 @@ public class ProfileTokenResponse {
     private String profileImage;
     private String token;
 
-    public ProfileTokenResponse(ProfileResponse profile, String token) {
-        this.id = profile.getId();
-        this.memberId = profile.getMemberId();
-        this.nickname = profile.getNickname();
-        this.profileImage = profile.getProfileImage();
+    public ProfileTokenResponse(Member member, String token) {
+        this.id = member.getId();
+        this.memberId = member.getMemberId();
+        this.nickname = member.getNickname();
+        this.profileImage = member.getProfileImage();
         this.token = token;
     }
 

--- a/backend/goodday/src/main/java/seeuthere/goodday/auth/service/AuthService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import seeuthere.goodday.auth.dto.ProfileResponse;
 import seeuthere.goodday.auth.dto.ProfileTokenResponse;
 import seeuthere.goodday.auth.infrastructure.JwtTokenProvider;
+import seeuthere.goodday.member.domain.Member;
 import seeuthere.goodday.member.service.MemberService;
 
 @Service
@@ -17,9 +18,9 @@ public class AuthService {
         this.memberService = memberService;
     }
 
-    public ProfileTokenResponse createToken(ProfileResponse profile) {
-        String token = jwtTokenProvider.createToken(profile.getId());
-        return new ProfileTokenResponse(profile, token);
+    public ProfileTokenResponse createToken(Member member) {
+        String token = jwtTokenProvider.createToken(member.getId());
+        return new ProfileTokenResponse(member, token);
     }
 
     public void validate(String token) {

--- a/backend/goodday/src/main/java/seeuthere/goodday/member/service/MemberService.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/service/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
                 new Member(profile.getId(), memberId, profile.getNickname(),
                     profile.getProfileImage()));
         }
-        return null;
+        return find(profile.getId());
     }
 
     private String generateRandomMemberId() {

--- a/backend/goodday/src/test/java/seeuthere/goodday/member/domain/MemberTest.java
+++ b/backend/goodday/src/test/java/seeuthere/goodday/member/domain/MemberTest.java
@@ -48,13 +48,12 @@ class MemberTest {
         assertThat(memberService.find("12345")).isEqualTo(member);
     }
 
-    @DisplayName("첫 로그인이 아닐 시 멤버를 저장하지 않는다.")
+    @DisplayName("첫 로그인이 아닐 시 기존의 멤버를 반환한다.")
     @Test
     public void alreadyMemberNotSave() {
-        ProfileResponse profile = new ProfileResponse("12345", "abcd", "영범허", "imageLink");
-        memberService.add(profile);
+        ProfileResponse profile = new ProfileResponse(와이비.getId(), "absscd", 와이비.getNickname(), 와이비.getProfileImage());
         Member member = memberService.add(profile);
-        assertThat(member).isNull();
+        assertThat(member.getMemberId()).isEqualTo(와이비.getMemberId());
     }
 
     @DisplayName("회원의 주소를 저장한다")


### PR DESCRIPTION

### 💡 다음 이슈를 해결했어요.
- 첫 로그인이 아닌경우 회원의 memberId를 반환하도록 수정했습니다

<br><br>



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
