### PR TITLE
fix: 친구 조회시 순서 보장하도록 수정

### DIFF
--- a/backend/goodday/src/main/java/seeuthere/goodday/member/domain/FriendShip.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/domain/FriendShip.java
@@ -58,6 +58,8 @@ public class FriendShip {
     public static class Key implements Serializable {
 
         private String ownerId;
+
         private String friendId;
     }
+
 }

--- a/backend/goodday/src/main/java/seeuthere/goodday/member/domain/Member.java
+++ b/backend/goodday/src/main/java/seeuthere/goodday/member/domain/Member.java
@@ -1,6 +1,7 @@
 package seeuthere.goodday.member.domain;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -83,6 +84,7 @@ public class Member {
     public List<Member> getMemberFriends() {
         return this.friends.stream()
             .map(FriendShip::getFriend)
+            .sorted(Comparator.comparing(Member::getNickname))
             .collect(Collectors.toList());
     }
 

--- a/backend/goodday/src/test/java/seeuthere/goodday/member/domain/MemberTest.java
+++ b/backend/goodday/src/test/java/seeuthere/goodday/member/domain/MemberTest.java
@@ -127,8 +127,8 @@ class MemberTest {
         assertThat(friends.size()).isEqualTo(2);
         assertThat(friends.stream()
             .map(FriendResponse::getNickname)
-            .collect(Collectors.toList()
-            ).containsAll(Arrays.asList(심바.getNickname(), 멍토.getNickname()))).isTrue();
+            .collect(Collectors.toList()))
+            .containsExactly(멍토.getNickname(), 심바.getNickname());
     }
 
     @DisplayName("친구를 삭제한다")


### PR DESCRIPTION
<!--- 
# 뒤에 머지 후 close할 이슈번호를 적어주세요. 자동으로 close 됩니다.
--->
<strong>
Closes #126 
</strong>

### 💡 다음 이슈를 해결했어요.
- 친구 조회시 순서 보장하도록 수정

<br><br>


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
