### PR TITLE
[4] 프론트엔드 테스트 자동화 적용

### DIFF
--- a/.github/workflows/fe-tests.yml
+++ b/.github/workflows/fe-tests.yml
@@ -17,8 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install NPM dependencies
-        run: |
-          npm install
+        run: npm install
         working-directory: ${{ env.working-directory }}
 
       - name: Run browser & cypress

--- a/.github/workflows/fe-tests.yml
+++ b/.github/workflows/fe-tests.yml
@@ -1,0 +1,26 @@
+name: Front-End Cypress Tests
+
+on:
+  push:
+    branches: ['**/front*']
+
+  workflow_dispatch:
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-20.04
+    env:
+      working-directory: ./frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install NPM dependencies
+        run: |
+          npm install
+        working-directory: ${{ env.working-directory }}
+
+      - name: Run browser & cypress
+        run: npm run test
+        working-directory: ${{ env.working-directory }}

--- a/frontend/cypress/integration/midpoint.spec.js
+++ b/frontend/cypress/integration/midpoint.spec.js
@@ -17,10 +17,6 @@ describe('HomePage & MidpointPage', () => {
       cy.addParticipant(p);
 
       cy.get(`ul[data-testid=${ID.PARTICIPANT_LIST}]`).contains('li', participants[i].name);
-
-      i === 0
-        ? cy.get(`button[data-testid=${ID.MIDPOINT_FINDER}]`).should('be.disabled')
-        : cy.get(`button[data-testid=${ID.MIDPOINT_FINDER}]`).should('be.enabled');
     });
   });
 

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -9,6 +9,8 @@ Cypress.Commands.add('addParticipant', ({ fixture, name, addressSearchKeyword })
 
   cy.get(`input[data-testid=${ID.ADDRESS_SEARCH}]`).type(addressSearchKeyword);
   cy.get(`input[data-testid=${ID.ADDRESS_SEARCH}]`).siblings('button').click();
+
+  cy.wait(2000);
   cy.get(`ul[data-testid=${ID.ADDRESS_SEARCH}]`).children().first().click();
 
   cy.get(`button[data-testid=${ID.PARTICIPANT_ADD_BUTTON}]`).click();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1265,6 +1265,21 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -1371,6 +1386,27 @@
           "dev": true
         }
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "7.28.0",
@@ -2075,6 +2111,15 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.1.tgz",
       "integrity": "sha512-3WVgVPs/7OnKU3s+lqMtkv3wQlg3WxK1YifmpJSDO0E1aPBrZWlrrTO6cxRqCXLuX2aYgCljqXIQd0VnRidV0g==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -3571,6 +3616,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4057,6 +4108,21 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
     },
     "eventemitter2": {
       "version": "6.4.4",
@@ -4581,6 +4647,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "fs-extra": {
@@ -5568,6 +5640,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -6097,6 +6182,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "map-visit": {
@@ -6723,6 +6814,15 @@
         "isarray": "0.0.1"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6877,6 +6977,15 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
     },
     "psl": {
       "version": "1.8.0",
@@ -8022,6 +8131,15 @@
         }
       }
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8060,6 +8178,21 @@
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
       "dev": true
     },
+    "start-server-and-test": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.13.1.tgz",
+      "integrity": "sha512-wZjksmjG5scEHXmV/3HWzImxNzUgaNQ6W8kkqL2GbiOldM+nqiqh7niimlC9ZGNopTGj16kheWZnZtSWgdBZNQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.7.2",
+        "check-more-types": "2.24.0",
+        "debug": "4.3.2",
+        "execa": "5.1.1",
+        "lazy-ass": "1.6.0",
+        "ps-tree": "1.2.0",
+        "wait-on": "6.0.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -8086,6 +8219,15 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
     },
     "string-width": {
       "version": "4.2.2",
@@ -8740,6 +8882,36 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "wait-on": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
+      "integrity": "sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "joi": "^17.4.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.5",
+        "rxjs": "^7.1.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+          "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "watchpack": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "see-you-there-frontend",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "start": "webpack serve --mode=development",
     "lint": "eslint src",
     "build": "webpack --mode=production",
-    "cypress": "cypress open --config watchForFileChanges=false --config pluginsFile=false --config-file false"
+    "cypress": "cypress open --config watchForFileChanges=false,pluginsFile=false --config-file false",
+    "cypress:run": "cypress run --config pluginsFile=false --config-file false",
+    "test": "start-server-and-test start http-get://localhost:9000 cypress:run"
   },
   "contributors": [
     {
@@ -110,6 +112,7 @@
     "html-webpack-plugin": "5.3.2",
     "prettier": "2.3.2",
     "react-refresh": "0.10.0",
+    "start-server-and-test": "1.13.1",
     "url-loader": "4.1.1",
     "webpack": "5.45.1",
     "webpack-cli": "4.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "see-you-there-frontend",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "여기서만나(프론트엔드)",
   "main": "index.js",
   "scripts": {

--- a/frontend/src/contexts/MapViewContext.js
+++ b/frontend/src/contexts/MapViewContext.js
@@ -67,6 +67,10 @@ export const MapViewContextProvider = ({ children }) => {
 
   const [station] = stations || [];
 
+  if (station) {
+    station.placeName = station.placeName?.split(' ')[0];
+  }
+
   const { data: categoryPlace, isLoading: isCategoryPlaceLoading } = useQuery([category, station], fetchCategory, {
     enabled: !!station && !!category,
   });

--- a/frontend/src/pages/Login/index.js
+++ b/frontend/src/pages/Login/index.js
@@ -4,9 +4,10 @@ import { Anchor, ContentArea } from './style';
 import { API_URL } from '../../constants';
 import { Image } from '../../assets';
 
+// TODO: 네이버 로그인 동작 시 주석 해제
 const companies = [
   { name: '카카오', imgSrc: Image.logoKakao, backgroundColor: '#FEE500', url: API_URL.LOGIN_KAKAO },
-  { name: '네이버', imgSrc: Image.logoNaver, backgroundColor: '#FFFFFF', url: API_URL.LOGIN_NAVER },
+  // { name: '네이버', imgSrc: Image.logoNaver, backgroundColor: '#FFFFFF', url: API_URL.LOGIN_NAVER },
 ];
 
 export const Login = () => {

--- a/frontend/src/pages/Midpoint/index.js
+++ b/frontend/src/pages/Midpoint/index.js
@@ -136,7 +136,9 @@ export const Midpoint = () => {
 
               <PersonalPath transport={transport} participant={participant} station={station} />
             </PathSection>
-            <Footer>공공 API 를 사용하고 있습니다.</Footer> {/* //TODO: 정확한 명칭으로 수정 */}
+            <Footer>
+              서울특별시_대중교통환승경로 조회 서비스 <br /> by 서울특별시 교통정보과, CC BY
+            </Footer>
           </Content>
         </ContentArea>
       </main>

--- a/frontend/src/pages/Midpoint/style.js
+++ b/frontend/src/pages/Midpoint/style.js
@@ -456,6 +456,7 @@ export const Footer = styled.div`
   margin: ${LAYOUT.MARGIN};
   margin-top: 3rem;
 
+  text-align: end;
   font-size: 0.6rem;
   color: ${COLOR.PARAGRAPH_LIGHT};
 `;


### PR DESCRIPTION
<!--- 
# 뒤에 머지 후 close할 이슈번호를 적어주세요. 자동으로 close 됩니다.
--->
<strong>
Closes #134
</strong>

### 💡 다음 이슈를 해결했어요.
- front-* 브랜치의 push 시점에 테스트를 자동으로 실행하는 Github Action을 설정하였습니다.
<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- 테스트 자동화를 위해 start-server-and-test 패키지를 추가했습니다.

<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- GPU is mine의 깔-끔 한 yml 파일을 참고했습니다.
  - https://github.com/woowacourse-teams/2021-gpu-is-mine/blob/develop/.github/workflows/gpu-is-mine-CI.yml

<br><br>



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
